### PR TITLE
Wrong packer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Plug 'npxbr/glow.nvim', {'do': ':GlowInstall', 'branch': 'main'}
 with [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```
-use {"npxbr/glow.nvim", run = "GlowInstall"}
+use {"npxbr/glow.nvim", cmd = ":GlowInstall"}
 ```
 
 ## Usage


### PR DESCRIPTION
`Packer` installation fails with `run = "GlowInstall"` as `run` rather for shell commands. With  `cmd = ":GlowInstall"` works as expected.